### PR TITLE
[Fix](Android flutter sdk error)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To use Chargebee SDK in your Flutter app, follow these steps:
 
     ```dart
     dependencies: 
-     chargebee_flutter: ^0.0.6
+     chargebee_flutter: ^0.0.7
     ```
     
 2.  Install dependency.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.chargebee.flutter.sdk'
-version '0.0.6'
+version '0.0.7'
 
 buildscript {
     ext.kotlin_version = '1.6.0'

--- a/android/src/main/kotlin/com/chargebee/flutter/sdk/ChargebeeFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/chargebee/flutter/sdk/ChargebeeFlutterSdkPlugin.kt
@@ -190,7 +190,7 @@ class ChargebeeFlutterSdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
                     }
                 })
         }catch (exp: Exception){
-            result.error(exp.message,exp.message, exp)
+            result.error("${exp.message}",exp.message, exp)
         }
     }
 

--- a/android/src/main/kotlin/com/chargebee/flutter/sdk/ChargebeeFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/chargebee/flutter/sdk/ChargebeeFlutterSdkPlugin.kt
@@ -190,7 +190,8 @@ class ChargebeeFlutterSdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
                     }
                 })
         }catch (exp: Exception){
-            result.error("${exp.message}",exp.message, exp)
+            val errorMsg = exp.message ?: "${exp.message}"
+            result.error(errorMsg,errorMsg, exp)
         }
     }
 

--- a/ios/chargebee_flutter.podspec
+++ b/ios/chargebee_flutter.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'chargebee_flutter'
-  s.version          = '0.0.6'
+  s.version          = '0.0.7'
   s.summary          = 'This is the official Software Development Kit (SDK) for Chargebee Flutter.'
   s.description      = <<-DESC
 A new Flutter plugin.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chargebee_flutter
 description: This is the official Software Development Kit (SDK) for Chargebee Flutter.
-version: 0.0.6
+version: 0.0.7
 homepage: 'https://chargebee.com'
 repository: 'https://github.com/chargebee/chargebee-flutter'
 


### PR DESCRIPTION
Fixed: Type mismatch: inferred type is String? but String was expected during android build
The issue has found in latest flutter sdk v3.3.10 while launching the app. Analysed the issue and found that there are code changes around the MethodChannel.java class in flutter engine, here are the code comparison link - https://github.com/flutter/engine/compare/flutter-2.12-candidate.2...flutter-2.12-candidate.3