### PR TITLE
Product: Add missing currencyCode

### DIFF
--- a/example/lib/product_listview.dart
+++ b/example/lib/product_listview.dart
@@ -47,7 +47,7 @@ class ProductListViewState extends State<ProductListView> {
                       color: Colors.black54,
                         fontWeight: FontWeight.bold,
                         fontSize: 18)),
-                subtitle: Text(listProducts[pos].price,
+                subtitle: Text(listProducts[pos].price + " (currencyCode: "+ listProducts[pos].currencyCode + ")",
                     style: const TextStyle(
                         fontWeight: FontWeight.normal,
                         fontSize: 15)),

--- a/lib/src/utils/product.dart
+++ b/lib/src/utils/product.dart
@@ -3,13 +3,15 @@ class Product {
   String id;
   String price;
   String title;
-  Product(this.id, this.price, this.title);
+  String currencyCode;
+
+  Product(this.id, this.price, this.title, this.currencyCode);
 
   factory Product.fromJson(dynamic json) {
     print(json);
 
     return Product(json['productId'] as String, json['productPrice'] as String,
-        json['productTitle'] as String);
+        json['productTitle'] as String, json['currencyCode'] as String);
   }
 }
 


### PR DESCRIPTION
The information was already provided by the Chargebee native sdks, someone just forgot to pass them to the app.

I do not know if this information is *always* provided, but in our app using our subscriptions we set up on the Appstore and the Play Store, they were.

**Related:**
- Partially fixes this: #39 