### PR TITLE
Minor codequality improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,12 @@ Initialize the Chargebee Flutter SDK with your Chargebee site, Publishable API K
 ```dart
 import 'package:chargebee_flutter/chargebee_flutter.dart';
 try {
-  await Chargebee.configure("SITE_NAME", "API-KEY", "iOS SDK Key", "Android SDK Key");
+  await Chargebee.configure(
+    site: "SITE_NAME",
+    publishableApiKey: "API_KEY",
+    iosSdkKey: "iOS_SDK_Key",
+    androidSdkKey: "Android_SDK_Key",
+  );
 } on PlatformException catch (e) {
   print('${e.message}, ${e.details}');
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -129,7 +129,12 @@ class _MyHomePageState extends State<MyHomePage> {
   Future<void> authentication(String siteName, String apiKey, [String? iosSdkKey="",
       String? androidSdkKey = ""]) async {
     try {
-      await Chargebee.configure(siteName, apiKey, iosSdkKey, androidSdkKey);
+      await Chargebee.configure(
+        site: siteName,
+        publishableApiKey: apiKey,
+        androidSdkKey: androidSdkKey,
+        iosSdkKey: iosSdkKey,
+      );
     } on PlatformException catch (e) {
       print('${e.message}, ${e.details}');
     }

--- a/example/lib/product_listview.dart
+++ b/example/lib/product_listview.dart
@@ -47,7 +47,7 @@ class ProductListViewState extends State<ProductListView> {
                       color: Colors.black54,
                         fontWeight: FontWeight.bold,
                         fontSize: 18)),
-                subtitle: Text(listProducts[pos].price,
+                subtitle: Text(listProducts[pos].price + " (currencyCode: "+ listProducts[pos].currencyCode + ")",
                     style: const TextStyle(
                         fontWeight: FontWeight.normal,
                         fontSize: 15)),

--- a/lib/src/chargebee.dart
+++ b/lib/src/chargebee.dart
@@ -13,8 +13,12 @@ class Chargebee {
   static bool get _isIOS => defaultTargetPlatform == TargetPlatform.iOS;
 
   /* Configure the app details with chargebee system */
-  static Future<void> configure(String site, String publishableApiKey,
-      [String? iosSdkKey = "", androidSdkKey = ""]) async {
+  static Future<void> configure({
+    required String site,
+    required String publishableApiKey,
+    String? iosSdkKey = "",
+    String? androidSdkKey = "",
+  }) async {
     if (_isIOS) {
       final args = {
         Constants.siteName: site,

--- a/lib/src/chargebee.dart
+++ b/lib/src/chargebee.dart
@@ -7,6 +7,8 @@ import 'package:flutter/services.dart';
 import 'dart:convert';
 
 class Chargebee {
+  Chargebee._();
+
   static const platform = MethodChannel(Constants.methodChannelName);
   static bool get _isIOS => defaultTargetPlatform == TargetPlatform.iOS;
 

--- a/lib/src/utils/product.dart
+++ b/lib/src/utils/product.dart
@@ -3,13 +3,15 @@ class Product {
   String id;
   String price;
   String title;
-  Product(this.id, this.price, this.title);
+  String currencyCode;
+
+  Product(this.id, this.price, this.title, this.currencyCode);
 
   factory Product.fromJson(dynamic json) {
     print(json);
 
     return Product(json['productId'] as String, json['productPrice'] as String,
-        json['productTitle'] as String);
+        json['productTitle'] as String, json['currencyCode'] as String);
   }
 }
 

--- a/lib/src/utils/product.dart
+++ b/lib/src/utils/product.dart
@@ -13,6 +13,11 @@ class Product {
     return Product(json['productId'] as String, json['productPrice'] as String,
         json['productTitle'] as String, json['currencyCode'] as String);
   }
+
+  @override
+  String toString() {
+    return 'Product(id: $id, price: $price, title: $title, currencyCode: $currencyCode)';
+  }
 }
 
 class PurchaseResult {
@@ -23,6 +28,11 @@ class PurchaseResult {
 
   factory PurchaseResult.fromJson(dynamic json) {
     return PurchaseResult(json['subscriptionId'] as String, json['planId'] as String, json['status'] as String);
+  }
+
+  @override
+  String toString() {
+    return 'PurchaseResult(subscriptionId: $subscriptionId, planId: $planId, $status)';
   }
 }
 

--- a/test/chargebee_test.dart
+++ b/test/chargebee_test.dart
@@ -34,7 +34,11 @@ void main() {
     test('works for iOS', () async {
       channelResponse = true;
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-      await Chargebee.configure(siteName, apiKey, iosSDKKey);
+      await Chargebee.configure(
+        site: siteName,
+        publishableApiKey: apiKey,
+        iosSdkKey: iosSDKKey,
+      );
       expect(callStack, <Matcher>[
         isMethodCall(
           Constants.mAuthentication,
@@ -50,7 +54,11 @@ void main() {
     test('works for android', () async {
       channelResponse = true;
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
-      await Chargebee.configure(siteName, apiKey, "", androidSDKKey);
+      await Chargebee.configure(
+        site: siteName,
+        publishableApiKey: apiKey,
+        androidSdkKey: androidSDKKey,
+      );
       expect(callStack, <Matcher>[
         isMethodCall(
           Constants.mAuthentication,
@@ -68,7 +76,12 @@ void main() {
         throw PlatformException(code: "Dummy");
       });
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-      await expectLater(() => Chargebee.configure(siteName, apiKey, iosSDKKey),
+      await expectLater(
+          () => Chargebee.configure(
+                site: siteName,
+                publishableApiKey: apiKey,
+                iosSdkKey: iosSDKKey,
+              ),
           throwsA(isA<PlatformException>()));
       channel.setMockMethodCallHandler(null);
     });


### PR DESCRIPTION
- [x] Private Chargebee() constructor
- [x] configure() now takes named args
- [x] Added toString() to Product & PurchaseResult

If this is merged, remember to update the minor version of this package, since this is a breaking change before v1.0.0. I'm assuming this package adheres to SemVer.