### PR TITLE
[Fix](retrieveAllPlans issue in CBPlan and configure error handling)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.9
+Bug fixes
+* flutter retrieve all plans issue - Response has no/invalid body. And the issue fixed in Native iOS SDK v1.0.17
+* Added configure() method callbacks to handle error case if any errors thrown from Chargebee during configuration
+  Fixed in this PR - https://github.com/chargebee/chargebee-ios/pull/56 and https://github.com/chargebee/chargebee-ios/pull/55
 ## 0.0.8
 Bug fixes
 * Android app crashed on signed apk and the issue fixed in Native Android SDK v1.0.15

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To use Chargebee SDK in your Flutter app, follow these steps:
 
     ```dart
     dependencies: 
-     chargebee_flutter: ^0.0.8
+     chargebee_flutter: ^0.0.9
     ```
     
 2.  Install dependency.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.chargebee.flutter.sdk'
-version '0.0.8'
+version '0.0.9'
 
 buildscript {
     ext.kotlin_version = '1.6.0'

--- a/android/src/main/kotlin/com/chargebee/flutter/sdk/ChargebeeFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/chargebee/flutter/sdk/ChargebeeFlutterSdkPlugin.kt
@@ -75,15 +75,11 @@ class ChargebeeFlutterSdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
             }
             "retrieveAllPlans" ->{
                 val params = call.arguments() as? Map<String, String>?
-                if (params != null) {
-                    retrieveAllPlans(params, result)
-                }
+                retrieveAllPlans(params, result)
             }
             "retrieveProductIdentifers" ->{
                 val params = call.arguments() as? Map<String, String>?
-                if (params != null) {
-                    retrieveProductIdentifers(params, result)
-                }
+                retrieveProductIdentifers(params, result)
             }
             "retrieveEntitlements" ->{
                 val params = call.arguments() as? Map<String, String>?
@@ -104,7 +100,7 @@ class ChargebeeFlutterSdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
         // Added chargebee logger support for flutter android sdk
         Chargebee.environment = "cb_flutter_android_sdk"
         // Configure with Chargebee SDK
-        Chargebee.configure(site = siteName, publishableApiKey = apiKey, sdkKey = sdkKey, packageName = "${activity.packageName}"){
+        Chargebee.configure(site = siteName, publishableApiKey = apiKey, sdkKey = sdkKey, packageName = "org.biblingo.biblingo"){
             when(it){
                 is ChargebeeResult.Success -> {
                     val response = (it.data) as CBAuthResponse

--- a/android/src/main/kotlin/com/chargebee/flutter/sdk/ChargebeeFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/chargebee/flutter/sdk/ChargebeeFlutterSdkPlugin.kt
@@ -100,7 +100,7 @@ class ChargebeeFlutterSdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
         // Added chargebee logger support for flutter android sdk
         Chargebee.environment = "cb_flutter_android_sdk"
         // Configure with Chargebee SDK
-        Chargebee.configure(site = siteName, publishableApiKey = apiKey, sdkKey = sdkKey, packageName = "org.biblingo.biblingo"){
+        Chargebee.configure(site = siteName, publishableApiKey = apiKey, sdkKey = sdkKey, packageName = "${activity.packageName}"){
             when(it){
                 is ChargebeeResult.Success -> {
                     val response = (it.data) as CBAuthResponse

--- a/ios/Classes/SwiftChargebeeFlutterSdkPlugin.swift
+++ b/ios/Classes/SwiftChargebeeFlutterSdkPlugin.swift
@@ -22,7 +22,17 @@ public class SwiftChargebeeFlutterSdkPlugin: NSObject, FlutterPlugin {
             Chargebee.environment = "cb_flutter_ios_sdk"
             Chargebee.configure(site: args["site_name"] as! String,
                                 apiKey: args["api_key"] as! String,
-                                sdkKey: (args["sdk_key"] as! String))
+                                sdkKey: (args["sdk_key"] as! String)) { result in
+                switch result {
+                case .success(let status):
+                    _result(status.details.status!)
+                case .error(let error):
+                    print("error : \(error)")
+                    _result(FlutterError.chargebeeError(error as NSError))
+                    
+                }
+            }
+            
         case "retrieveSubscriptions":
             guard let args = call.arguments as? [String: String] else {
                 return _result(FlutterError.noArgsError)

--- a/ios/chargebee_flutter.podspec
+++ b/ios/chargebee_flutter.podspec
@@ -14,7 +14,7 @@ A new Flutter plugin.
   s.dependency 'Flutter'
   s.platform = :ios, '12.0'
 
-  s.dependency 'Chargebee', '1.0.15'
+  s.dependency 'Chargebee', '1.0.17'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/ios/chargebee_flutter.podspec
+++ b/ios/chargebee_flutter.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'chargebee_flutter'
-  s.version          = '0.0.8'
+  s.version          = '0.0.9'
   s.summary          = 'This is the official Software Development Kit (SDK) for Chargebee Flutter.'
   s.description      = <<-DESC
 A new Flutter plugin.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chargebee_flutter
 description: This is the official Software Development Kit (SDK) for Chargebee Flutter.
-version: 0.0.8
+version: 0.0.9
 homepage: 'https://chargebee.com'
 repository: 'https://github.com/chargebee/chargebee-flutter'
 


### PR DESCRIPTION
Issue: The issue has occurred while retrieving all the plans and get product identifiers from server. error details( Response has no/invalid body).
Fix: Updated meta data mapping in CBPlan on native iOS sdk. and also added handler to configure method.
Native PR link's - https://github.com/chargebee/chargebee-ios/pull/55 and https://github.com/chargebee/chargebee-ios/pull/56