### PR TITLE
Make it compatible with AGP 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+      namespace 'com.chargebee.flutter.sdk'
+    }
+
     compileSdkVersion 30
 
     compileOptions {


### PR DESCRIPTION
The Android gradle plugin (AGP) in version 8 requires namespaces.
The solution was copied from the official cloud_firestore package and leads to a successful gradle sync.