### PR TITLE
fix: change encoding from ascii to utf8

### DIFF
--- a/ios/Classes/SwiftChargebeeFlutterSdkPlugin.swift
+++ b/ios/Classes/SwiftChargebeeFlutterSdkPlugin.swift
@@ -78,7 +78,7 @@ public class SwiftChargebeeFlutterSdkPlugin: NSObject, FlutterPlugin {
                                     withJSONObject:dict,
                                     options: []) {
                                     if let jsonString = String(data: data,
-                                                               encoding: .ascii) {
+                                                               encoding: .utf8) {
                                         _result(jsonString)
                                     }
                                 }else {
@@ -120,7 +120,7 @@ public class SwiftChargebeeFlutterSdkPlugin: NSObject, FlutterPlugin {
                                     withJSONObject:dict,
                                     options: []) {
                                     if let jsonString = String(data: data,
-                                                               encoding: .ascii) {
+                                                               encoding: .utf8) {
                                         _result(jsonString)
                                     }
                                 }else {
@@ -152,7 +152,7 @@ public class SwiftChargebeeFlutterSdkPlugin: NSObject, FlutterPlugin {
                                 withJSONObject: product.product.toMap(),
                                 options: []) {
                                 if let jsonString = String(data: theJSONData,
-                                                           encoding: .ascii) {
+                                                           encoding: .utf8) {
                                     array.append(jsonString)
                                 }
                             }
@@ -173,7 +173,7 @@ public class SwiftChargebeeFlutterSdkPlugin: NSObject, FlutterPlugin {
                             withJSONObject:dataWrapper.ids,
                             options: []) {
                             if let jsonString = String(data: data,
-                                                       encoding: .ascii) {
+                                                       encoding: .utf8) {
                                 _result(jsonString)
                             }
                         }else {


### PR DESCRIPTION
Product titles were displaying bad characters when dealing with diacritics. Example:

App Store entry: `Karnet na pół sezonu 2023/2024`

Chargebee title: `Karnet na pÃ³Å sezonu 2023/2024`

I've fixed above by changing ASCII encoding to UTF8.